### PR TITLE
ci: bump pixi v0.41.4 -> v0.60.0 to support lockfile format v6

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
+          pixi-version: v0.60.0
           manifest-path: pyproject.toml
       - name: build conda package
         run: |
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
+          pixi-version: v0.60.0
           manifest-path: pyproject.toml
       - name: build pypi package
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
+          pixi-version: v0.60.0
           manifest-path: pyproject.toml
       - name: run unit tests
         run: |


### PR DESCRIPTION
## Summary

The bot's `update-lockfiles.yml` workflow uses the latest `pixi`, which generates lock-file format v6. Our pinned `pixi-version: v0.41.4` in `unittest.yml` and `package.yml` cannot read this format, causing every auto-update PR to fail with:

> lock-file not up-to-date with the workspace

This blocked PR #165 (and would block all future monthly lockfile PRs). Bumping to `v0.60.0` (matching AvantVENUS/CylindricalGeometryCorrection/etc.) restores compatibility.

The pre-commit linter also updated `actions/checkout@v4 -> v6`, `prefix-dev/setup-pixi@v0.8.3 -> v0.9.5`, and `codecov/codecov-action@v5 -> v6` — all transparent SHA-pin refreshes from the autoupdate hook.

## Test plan

- [ ] Tests workflow passes on this PR
- [ ] After merge, retrigger PR #165 (lockfile update) and confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)