### PR TITLE
ci: bump pixi v0.60.0 -> v0.67.2 (matches bot's actual version)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.60.0
+          pixi-version: v0.67.2
           manifest-path: pyproject.toml
       - name: build conda package
         run: |
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.60.0
+          pixi-version: v0.67.2
           manifest-path: pyproject.toml
       - name: build pypi package
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.60.0
+          pixi-version: v0.67.2
           manifest-path: pyproject.toml
       - name: run unit tests
         run: |

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
+          pixi-version: v0.67.2
           run-install: false
       - name: Update lockfiles
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #166. Bumping to v0.60.0 was insufficient — PR #165's lockfile was generated with the bot's latest pixi (v0.67.2 effective via setup-pixi@v0.9.5 with no pin), and v0.60.0 still rejects it as "lock-file not up-to-date with the workspace".

This PR aligns all three workflows (unit-test, package, update-lockfiles) on v0.67.2 explicitly so future bot lockfile PRs stay validatable.

## Test plan

- [ ] Unit-test workflow passes on this PR
- [ ] After merge, retrigger PR #165 and confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)