### PR TITLE
Pin NeuNorm to v1.6.12 (stopgap for NeuNorm 2.0 break)

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
     - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/BraggEdge.git --no-deps --no-build-isolation -vvv
-    - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/NeuNorm.git --no-deps --no-build-isolation -vvv
+    - {{ PYTHON }} -m pip install git+https://github.com/ornlneutronimaging/NeuNorm.git@v1.6.12 --no-deps --no-build-isolation -vvv
 
 
 requirements:


### PR DESCRIPTION
Pins the unpinned `git+NeuNorm` install in `conda.recipe/meta.yaml` to the last NeuNorm 1.x release **`@v1.6.12`**.

NeuNorm 2.0 merged into its `next` on 2026-06-04 (NeuNorm PR #124), switching to the Hatchling backend and a breaking API. The unpinned install would pull 2.0 and break the conda build (`Cannot import 'hatchling.build'`) — latent here since `package.yml` only builds on `qa`/`main`/tags, so this pre-empts the break at the next promotion/release.

Stopgap for #175 (full context + the one-spot `crop.py` 2.0 port).

Assisted-With: Claude Opus 4.8 (1M context)