### PR TITLE
fix: pin neunorm to pre-2.0 (stopgap for #175)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6075,8 +6075,8 @@ packages:
   timestamp: 1733663449209
 - pypi: ./
   name: hyperctui
-  version: 0.1.0
-  sha256: f6859f9566c2f08fde42de6415d257e68a689e22b8798da6b80ff3c92b090296
+  version: 1.1.0.dev93+d202606100052
+  sha256: c6bc6e75108fe324a8745539e8cd2a56638c6c38615aed95f80f862726960673
   requires_dist:
   - pandas
   - pillow
@@ -6090,7 +6090,7 @@ packages:
   - pyqtgraph
   - tqdm
   - loguru
-  - neunorm
+  - neunorm>=1.6.12,<2
   - neutronbraggedge
   - pytest>=7.0.0 ; extra == 'dev'
   - pytest-cov ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dependencies = [
     "tqdm",
     "loguru",
     # neutron
-    "neunorm",
+    # NeuNorm 2.0 is a breaking rewrite (no NeuNorm.normalization.Normalization);
+    # pin to 1.x until crop.py is ported — see issue #175
+    "neunorm>=1.6.12,<2",
     "neutronbraggedge",
 ]
 


### PR DESCRIPTION
**NeuNorm 2.0.0 was published to PyPI on 2026-06-09** ([release](https://github.com/ornlneutronimaging/NeuNorm/releases/tag/v2.0.0)). It is a breaking, scipp-based rewrite: the 1.x `NeuNorm.normalization.Normalization` API that `src/hyperctui/crop/crop.py` imports no longer exists.

`pyproject.toml` currently declares a bare `"neunorm"`, so any fresh pip install of HyperCTui now resolves NeuNorm 2.0.0 and **breaks at import**. (Conda builds were unaffected — `conda.recipe/meta.yaml` already pins `git@v1.6.12`.)

This applies the stopgap that #175 calls for: pin `neunorm>=1.6.12,<2` until `crop.py` is ported to the 2.0 API. The proper port (tracked in #175) can follow NeuNorm's [1.x → 2.0 migration guide](https://github.com/ornlneutronimaging/NeuNorm/blob/main/docs/migration.md).

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)