### PR TITLE
fix: correctness batch from the 2026-06-11 audit (H3, H4 + eight M/L)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# Coverage policy (2026-06-11 audit recommendation): floor the project just
+# below its current ~27% so coverage can only ratchet up, and keep the patch
+# status informational until the GUI has a real test harness — most fix
+# lines live in Qt handlers that headless CI cannot exercise yet.
+coverage:
+  status:
+    project:
+      default:
+        target: 26%
+        threshold: 1%
+    patch:
+      default:
+        informational: true

--- a/src/hyperctui/autonomous_reconstruction/event_handler.py
+++ b/src/hyperctui/autonomous_reconstruction/event_handler.py
@@ -409,11 +409,11 @@ class EventHandler:
         )
 
         # updating the list of projections by adding the folders already acquired
+        # copy before extending: the previous code aliased the session's
+        # 'initially there' list and grew it on every refresh
+        previous_list_of_folders = list(list_projections_folders_initially_there)
         if list_projections_folders_acquired_so_far:
-            previous_list_of_folders = list_projections_folders_initially_there
             previous_list_of_folders.extend(list_projections_folders_acquired_so_far)
-        else:
-            previous_list_of_folders = list_projections_folders_initially_there
         logging.info(f"-> previous_list_of_folders:\n{formatting_list_for_print(previous_list_of_folders)}")
 
         # listing only the new folders
@@ -430,7 +430,8 @@ class EventHandler:
             starting_row_index = len(list_projections_folders_acquired_so_far)
 
             # to remove duplicates
-            list_projections_folders_acquired_so_far = list(set(list_projections_folders_acquired_so_far))
+            # order-preserving dedupe: list(set()) scrambled acquisition order
+            list_projections_folders_acquired_so_far = list(dict.fromkeys(list_projections_folders_acquired_so_far))
             list_projections_folders_acquired_so_far.extend(list_new_folders)
         else:
             starting_row_index = 0

--- a/src/hyperctui/autonomous_reconstruction/select_evaluation_regions.py
+++ b/src/hyperctui/autonomous_reconstruction/select_evaluation_regions.py
@@ -61,7 +61,12 @@ class SelectEvaluationRegions(QDialog):
         self.ui = load_ui(ui_full_path, baseinstance=self)
         self.setWindowTitle("Select Evaluation Regions")
 
-        self.parent.backup_evaluation_regions = self.parent.evaluation_regions
+        # structural copy: an alias made cancel a no-op because region drags
+        # mutate the dicts in place (live pyqtgraph refs under 'id' excluded)
+        self.parent.backup_evaluation_regions = {
+            _key: {k: v for k, v in _region.items() if k != "id"}
+            for _key, _region in self.parent.evaluation_regions.items()
+        }
         self.initialization()
         self.update_display_regions()
         self.check_state_ok_button()

--- a/src/hyperctui/autonomous_reconstruction/select_evaluation_regions.py
+++ b/src/hyperctui/autonomous_reconstruction/select_evaluation_regions.py
@@ -62,9 +62,19 @@ class SelectEvaluationRegions(QDialog):
         self.setWindowTitle("Select Evaluation Regions")
 
         # structural copy: an alias made cancel a no-op because region drags
-        # mutate the dicts in place (live pyqtgraph refs under 'id' excluded)
+        # mutate the dicts in place. Whitelist the DATA keys so no live
+        # pyqtgraph object (id, label_id) is carried into the backup
+        _data_keys = (
+            EvaluationRegionKeys.state,
+            EvaluationRegionKeys.name,
+            EvaluationRegionKeys.from_value,
+            EvaluationRegionKeys.to_value,
+            EvaluationRegionKeys.from_index,
+            EvaluationRegionKeys.to_index,
+            EvaluationRegionKeys.str_from_to_value,
+        )
         self.parent.backup_evaluation_regions = {
-            _key: {k: v for k, v in _region.items() if k != "id"}
+            _key: {k: v for k, v in _region.items() if k in _data_keys}
             for _key, _region in self.parent.evaluation_regions.items()
         }
         self.initialization()

--- a/src/hyperctui/crop/crop.py
+++ b/src/hyperctui/crop/crop.py
@@ -176,8 +176,11 @@ class Crop:
         left = self.parent.session_dict.get(SessionKeys.crop_left, default_left)
         right = self.parent.session_dict.get(SessionKeys.crop_right, default_right)
 
-        left = int(np.min([left, right]))
-        right = int(np.max([left, right]))
+        # tuple assignment: the previous sequential min/max overwrote left
+        # before computing right, collapsing inverted inputs to zero width
+        left, right = int(min(left, right)), int(max(left, right))
+        left = max(0, left)
+        right = min(width - 1, right)
 
         self.parent.session_dict[SessionKeys.crop_left] = left
         self.parent.session_dict[SessionKeys.crop_right] = right

--- a/src/hyperctui/crop/crop.py
+++ b/src/hyperctui/crop/crop.py
@@ -179,8 +179,11 @@ class Crop:
         # tuple assignment: the previous sequential min/max overwrote left
         # before computing right, collapsing inverted inputs to zero width
         left, right = int(min(left, right)), int(max(left, right))
-        left = max(0, left)
-        right = min(width - 1, right)
+        # clamp BOTH ends into [0, width-1]: clamping is monotone, so the
+        # left <= right ordering survives even when both stored values are
+        # out of range on the same side
+        left = min(max(0, left), width - 1)
+        right = min(max(0, right), width - 1)
 
         self.parent.session_dict[SessionKeys.crop_left] = left
         self.parent.session_dict[SessionKeys.crop_right] = right

--- a/src/hyperctui/initialization/gui_initialization.py
+++ b/src/hyperctui/initialization/gui_initialization.py
@@ -99,7 +99,7 @@ class GuiInitialization:
 
         recon_table_columns = [740, 80, 100]
         o_table = TableHandler(table_ui=self.parent.ui.autonomous_reconstructions_tableWidget)
-        o_table.set_column_sizes(column_sizes=table_columns)
+        o_table.set_column_sizes(column_sizes=recon_table_columns)
 
     def full_reset(self) -> None:
         """

--- a/src/hyperctui/pre_processing_monitor/event_handler.py
+++ b/src/hyperctui/pre_processing_monitor/event_handler.py
@@ -220,6 +220,10 @@ class EventHandler:
             if _folder in list_folder_previously_found:
                 continue
             list_new_projections_folders.append(_folder)
+        # deterministic 0/180 assignment: discovery order comes from an
+        # unsorted directory listing; the acquisition timestamp in the folder
+        # names makes a lexical sort chronological (same as the OB path)
+        list_new_projections_folders.sort()
 
         list_projections_folders_acquired_so_far = self.grand_parent.session_dict[
             SessionKeys.list_projections_folders_acquired_so_far
@@ -283,7 +287,11 @@ class EventHandler:
 
             if self.grand_parent.session_dict[SessionKeys.list_projections] is None:
                 self.grand_parent.session_dict[SessionKeys.list_projections] = [new_file]
-            else:
+            elif new_file not in self.grand_parent.session_dict[SessionKeys.list_projections]:
+                # every monitor refresh re-walks all rows; without this
+                # membership guard the session list accumulated duplicates
+                # ([A, A, B]) and the crop tab fed the 0-degree image to
+                # find_center_pc as the 180-degree image
                 self.grand_parent.session_dict[SessionKeys.list_projections].append(new_file)
 
             if _row == 0:

--- a/src/hyperctui/session/session_handler.py
+++ b/src/hyperctui/session/session_handler.py
@@ -142,7 +142,14 @@ class SessionHandler:
         try:
             right = int(self.parent.ui.crop_right_label_value.text())
         except ValueError:
-            right = width - 1
+            # fall back to the IMAGE width when known; the previous fallback
+            # used the main-window pixel width, which has nothing to do with
+            # the detector image
+            image_size = getattr(self.parent, "image_size", None)
+            if image_size:
+                right = image_size["width"] - 1
+            else:
+                right = width - 1
 
         session_dict[SessionKeys.crop_left] = left
         session_dict[SessionKeys.crop_right] = right

--- a/src/hyperctui/setup_ob/get.py
+++ b/src/hyperctui/setup_ob/get.py
@@ -14,6 +14,17 @@ from hyperctui.utilities.get import Get as MasterGet
 from hyperctui.utilities.table import TableHandler
 
 
+def is_ob_folder(folder_name: str) -> bool:
+    """True if a folder basename is an open-beam folder.
+
+    OB folders are created with an OB_/OBs_ prefix (see the main window's
+    OBs_{title} naming); the previous bare 'ob' substring test misrouted any
+    sample title containing 'ob' (Niobium, Cobalt, ...) into the OB list and
+    stalled the projections monitor forever.
+    """
+    return folder_name.lower().startswith(("ob_", "obs_"))
+
+
 class Get(MasterGet):
     """
     Class for retrieving Open Beam (OB) configuration data and paths.
@@ -164,7 +175,7 @@ class Get(MasterGet):
         list_ob_folders = []
         for _folder in list_folders:
             base_folder = os.path.basename(_folder)
-            if ("ob" in base_folder.lower()) and (title in base_folder):
+            if is_ob_folder(base_folder) and (title in base_folder):
                 list_ob_folders.append(_folder)
         return list_ob_folders
 
@@ -190,7 +201,7 @@ class Get(MasterGet):
         list_sample_folders = []
         for _folder in list_folders:
             base_folder = os.path.basename(_folder)
-            if ("ob" not in base_folder.lower()) and (title in base_folder):
+            if (not is_ob_folder(base_folder)) and (title in base_folder):
                 list_sample_folders.append(_folder)
         return list_sample_folders
 

--- a/src/hyperctui/utilities/file_utilities.py
+++ b/src/hyperctui/utilities/file_utilities.py
@@ -346,9 +346,9 @@ def get_list_img_files_from_top_folders(list_projections: List[str]) -> List[str
     """
     list_img_files = []
     for _projection in list_projections:
-        _folder = glob.glob(os.path.join(_projection, "Run_*"))
+        _folder = sorted(glob.glob(os.path.join(_projection, "Run_*")))
         if _folder:
-            img_file = glob.glob(os.path.join(_folder[0], "*_SummedImg.fits"))
+            img_file = sorted(glob.glob(os.path.join(_folder[0], "*_SummedImg.fits")))
             try:
                 list_img_files.append(img_file[0])
             except IndexError:

--- a/src/hyperctui/utilities/table.py
+++ b/src/hyperctui/utilities/table.py
@@ -118,7 +118,7 @@ class TableHandler:
             column: Column index of the cell to select
         """
         self.select_everything(False)
-        range_selected = QtGui.QTableWidgetSelectionRange(row, column, row, column)
+        range_selected = QTableWidgetSelectionRange(row, column, row, column)
         self.table_ui.setRangeSelected(range_selected, True)
 
     def select_row(self, row: int = 0) -> None:
@@ -179,7 +179,7 @@ class TableHandler:
         """
         self.table_ui.insertRow(row)
         for column, _text in enumerate(list_col_name):
-            _item = QtGui.QTableWidgetItem(_text)
+            _item = QTableWidgetItem(_text)
             self.table_ui.setItem(row, column, _item)
 
     def insert_column(self, column: int) -> None:
@@ -223,7 +223,7 @@ class TableHandler:
         if (str(float_value) == "None") or (str(float_value) == "N/A"):
             _str_value = "N/A"
         else:
-            _str_value = self.cell_str_format.format(np.float(float_value))
+            _str_value = self.cell_str_format.format(float(float_value))
         self.table_ui.item(row, column).setText(_str_value)
 
     def insert_item_with_float(
@@ -241,8 +241,8 @@ class TableHandler:
         if (str(float_value) == "None") or (str(float_value) == "N/A"):
             _str_value = "N/A"
         else:
-            _str_value = format_str.format(np.float(float_value))
-        _item = QtGui.QTableWidgetItem(_str_value)
+            _str_value = format_str.format(float(float_value))
+        _item = QTableWidgetItem(_str_value)
         self.table_ui.setItem(row, column, _item)
 
     def set_item_state(self, row: int = 0, column: int = 0, editable: bool = True) -> None:

--- a/src/hyperctui/utilities/widgets.py
+++ b/src/hyperctui/utilities/widgets.py
@@ -37,10 +37,15 @@ class Widgets(Parent):
         -------
         None
         """
+        # state guard: hiding when already hidden removed the Settings tab
+        # (reachable when a CropError fires during session load), and showing
+        # twice duplicated tabs
+        currently_visible = getattr(self.parent, "all_tabs_visible", True)
         if not is_visible:
-            for _ in np.arange(3):
-                self.parent.ui.tabWidget.removeTab(2)
-        else:
+            if currently_visible:
+                for _ in np.arange(3):
+                    self.parent.ui.tabWidget.removeTab(2)
+        elif not currently_visible:
             self.parent.ui.tabWidget.insertTab(2, self.parent.tab2, QIcon(tab2_icon), TabNames.tab2)
             self.parent.ui.tabWidget.insertTab(3, self.parent.tab3, QIcon(tab3_icon), TabNames.tab3)
             self.parent.ui.tabWidget.insertTab(4, self.parent.tab4, QIcon(tab4_icon), TabNames.tab4)

--- a/tests/unit/hyperctui/setup_ob/test_ob_classification.py
+++ b/tests/unit/hyperctui/setup_ob/test_ob_classification.py
@@ -1,0 +1,31 @@
+"""Regression tests for the OB-vs-sample folder classification (audit H4).
+
+The previous bare 'ob' substring test misrouted any sample title containing
+'ob' (Niobium, Cobalt, ...) into the OB list, leaving the sample list empty
+and stalling the projections monitor forever.
+"""
+
+import pytest
+
+from hyperctui.setup_ob.get import is_ob_folder
+
+
+@pytest.mark.parametrize(
+    "folder_name",
+    ["OB_Niobium_rod_20260611", "OBs_cobalt_sample", "ob_run_0001", "obs_whatever"],
+)
+def test_ob_prefixes_classify_as_ob(folder_name):
+    assert is_ob_folder(folder_name)
+
+
+@pytest.mark.parametrize(
+    "folder_name",
+    [
+        "Niobium_rod_20260611",  # previously misrouted: contains 'ob'
+        "cobalt_sample_0002",  # previously misrouted: contains 'ob'
+        "Strobe_test",  # previously misrouted: contains 'ob'
+        "sample_run_0001",
+    ],
+)
+def test_sample_titles_containing_ob_are_not_ob(folder_name):
+    assert not is_ob_folder(folder_name)

--- a/tests/unit/hyperctui/utilities/test_table_handler.py
+++ b/tests/unit/hyperctui/utilities/test_table_handler.py
@@ -6,9 +6,13 @@ so they crashed on first use; exercised here against a real offscreen
 QTableWidget.
 """
 
+import pytest
 from qtpy.QtWidgets import QTableWidget
 
 from hyperctui.utilities.table import TableHandler
+
+# every test needs the session QApplication (offscreen)
+pytestmark = pytest.mark.usefixtures("qapp")
 
 
 def _table(rows: int = 3, columns: int = 2) -> QTableWidget:
@@ -18,21 +22,21 @@ def _table(rows: int = 3, columns: int = 2) -> QTableWidget:
     return table_ui
 
 
-def test_insert_item_with_float_formats_value(qapp):
+def test_insert_item_with_float_formats_value():
     table_ui = _table()
     o_table = TableHandler(table_ui=table_ui)
     o_table.insert_item_with_float(row=0, column=0, float_value=3.14159, format_str="{:.2f}")
     assert table_ui.item(0, 0).text() == "3.14"
 
 
-def test_insert_item_with_float_handles_na(qapp):
+def test_insert_item_with_float_handles_na():
     table_ui = _table()
     o_table = TableHandler(table_ui=table_ui)
     o_table.insert_item_with_float(row=0, column=0, float_value="N/A")
     assert table_ui.item(0, 0).text() == "N/A"
 
 
-def test_set_item_with_float_updates_existing_item(qapp):
+def test_set_item_with_float_updates_existing_item():
     table_ui = _table()
     o_table = TableHandler(table_ui=table_ui)
     o_table.insert_item_with_float(row=1, column=1, float_value=1.0)
@@ -40,7 +44,7 @@ def test_set_item_with_float_updates_existing_item(qapp):
     assert table_ui.item(1, 1).text() == "2.5"
 
 
-def test_select_cell_selects_exactly_that_cell(qapp):
+def test_select_cell_selects_exactly_that_cell():
     table_ui = _table()
     o_table = TableHandler(table_ui=table_ui)
     o_table.select_cell(row=2, column=1)

--- a/tests/unit/hyperctui/utilities/test_table_handler.py
+++ b/tests/unit/hyperctui/utilities/test_table_handler.py
@@ -1,0 +1,50 @@
+"""Tests for the TableHandler methods repaired in the correctness batch.
+
+These methods previously called np.float (removed in NumPy >= 1.24) and
+QtGui.QTableWidgetItem / QtGui.QTableWidgetSelectionRange (wrong Qt module),
+so they crashed on first use; exercised here against a real offscreen
+QTableWidget.
+"""
+
+from qtpy.QtWidgets import QTableWidget
+
+from hyperctui.utilities.table import TableHandler
+
+
+def _table(rows: int = 3, columns: int = 2) -> QTableWidget:
+    table_ui = QTableWidget()
+    table_ui.setRowCount(rows)
+    table_ui.setColumnCount(columns)
+    return table_ui
+
+
+def test_insert_item_with_float_formats_value(qapp):
+    table_ui = _table()
+    o_table = TableHandler(table_ui=table_ui)
+    o_table.insert_item_with_float(row=0, column=0, float_value=3.14159, format_str="{:.2f}")
+    assert table_ui.item(0, 0).text() == "3.14"
+
+
+def test_insert_item_with_float_handles_na(qapp):
+    table_ui = _table()
+    o_table = TableHandler(table_ui=table_ui)
+    o_table.insert_item_with_float(row=0, column=0, float_value="N/A")
+    assert table_ui.item(0, 0).text() == "N/A"
+
+
+def test_set_item_with_float_updates_existing_item(qapp):
+    table_ui = _table()
+    o_table = TableHandler(table_ui=table_ui)
+    o_table.insert_item_with_float(row=1, column=1, float_value=1.0)
+    o_table.set_item_with_float(row=1, column=1, float_value=2.5)
+    assert table_ui.item(1, 1).text() == "2.5"
+
+
+def test_select_cell_selects_exactly_that_cell(qapp):
+    table_ui = _table()
+    o_table = TableHandler(table_ui=table_ui)
+    o_table.select_cell(row=2, column=1)
+    ranges = table_ui.selectedRanges()
+    assert len(ranges) == 1
+    r = ranges[0]
+    assert (r.topRow(), r.leftColumn(), r.bottomRow(), r.rightColumn()) == (2, 1, 2, 1)

--- a/tests/unit/hyperctui/utilities/test_widgets_tabs_guard.py
+++ b/tests/unit/hyperctui/utilities/test_widgets_tabs_guard.py
@@ -1,0 +1,42 @@
+"""Regression tests for the make_tabs_visible state guard (audit M finding).
+
+Hiding when already hidden used to remove the Settings tab (reachable when a
+CropError fires during session load); showing twice duplicated tabs.
+"""
+
+from unittest.mock import MagicMock
+
+from hyperctui.utilities.widgets import Widgets
+
+
+def _parent(all_tabs_visible: bool) -> MagicMock:
+    parent = MagicMock()
+    parent.all_tabs_visible = all_tabs_visible
+    return parent
+
+
+def test_hide_when_visible_removes_three_tabs(qapp):
+    parent = _parent(True)
+    Widgets(parent=parent).make_tabs_visible(is_visible=False)
+    assert parent.ui.tabWidget.removeTab.call_count == 3
+    assert parent.all_tabs_visible is False
+
+
+def test_hide_when_already_hidden_is_a_noop(qapp):
+    """the Settings-tab destruction bug: a second hide must not remove more tabs"""
+    parent = _parent(False)
+    Widgets(parent=parent).make_tabs_visible(is_visible=False)
+    parent.ui.tabWidget.removeTab.assert_not_called()
+
+
+def test_show_when_hidden_inserts_three_tabs(qapp):
+    parent = _parent(False)
+    Widgets(parent=parent).make_tabs_visible(is_visible=True)
+    assert parent.ui.tabWidget.insertTab.call_count == 3
+    assert parent.all_tabs_visible is True
+
+
+def test_show_when_already_visible_is_a_noop(qapp):
+    parent = _parent(True)
+    Widgets(parent=parent).make_tabs_visible(is_visible=True)
+    parent.ui.tabWidget.insertTab.assert_not_called()

--- a/tests/unit/hyperctui/utilities/test_widgets_tabs_guard.py
+++ b/tests/unit/hyperctui/utilities/test_widgets_tabs_guard.py
@@ -6,7 +6,12 @@ CropError fires during session load); showing twice duplicated tabs.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from hyperctui.utilities.widgets import Widgets
+
+# every test needs the session QApplication (offscreen)
+pytestmark = pytest.mark.usefixtures("qapp")
 
 
 def _parent(all_tabs_visible: bool) -> MagicMock:
@@ -15,28 +20,28 @@ def _parent(all_tabs_visible: bool) -> MagicMock:
     return parent
 
 
-def test_hide_when_visible_removes_three_tabs(qapp):
+def test_hide_when_visible_removes_three_tabs():
     parent = _parent(True)
     Widgets(parent=parent).make_tabs_visible(is_visible=False)
     assert parent.ui.tabWidget.removeTab.call_count == 3
     assert parent.all_tabs_visible is False
 
 
-def test_hide_when_already_hidden_is_a_noop(qapp):
+def test_hide_when_already_hidden_is_a_noop():
     """the Settings-tab destruction bug: a second hide must not remove more tabs"""
     parent = _parent(False)
     Widgets(parent=parent).make_tabs_visible(is_visible=False)
     parent.ui.tabWidget.removeTab.assert_not_called()
 
 
-def test_show_when_hidden_inserts_three_tabs(qapp):
+def test_show_when_hidden_inserts_three_tabs():
     parent = _parent(False)
     Widgets(parent=parent).make_tabs_visible(is_visible=True)
     assert parent.ui.tabWidget.insertTab.call_count == 3
     assert parent.all_tabs_visible is True
 
 
-def test_show_when_already_visible_is_a_noop(qapp):
+def test_show_when_already_visible_is_a_noop():
     parent = _parent(True)
     Widgets(parent=parent).make_tabs_visible(is_visible=True)
     parent.ui.tabWidget.insertTab.assert_not_called()


### PR DESCRIPTION
## Summary

HyperCTui PR 4 of 5 (`audits/HyperCTui_audit_2026-06-11.md`): the correctness batch — the two remaining H-severity logic bugs plus eight mechanical M/L fixes. Every fix maps to an adversarially-verified finding.

| Finding | Fix |
|---|---|
| **H3 — session duplication → wrong center of rotation** | Monitor refresh now guards membership before appending to `list_projections` (`[A, A, B]` previously fed the 0° image to `find_center_pc` as the 180° image); new-folder discovery is sorted so 0/180 assignment is deterministic (lexical = chronological for timestamped folder names, matching the OB path). Works with the exactly-2 `CropError` guard from #179 as defense-in-depth. |
| **H4 — 'ob' substring misroutes Niobium/Cobalt** | Classification by `OB_`/`OBs_` prefix (the actual naming convention) via an extracted, unit-tested predicate — sample titles containing 'ob' previously emptied the sample list and stalled the monitor forever. 8 new tests. |
| Crop min/max collapse | Tuple swap + clamp to `[0, width-1]` — sequential min/max overwrote `left` before computing `right`, collapsing inverted inputs to a 1-pixel crop fed to the CoR calculation |
| Session crop_right fallback | Falls back to the **image** width, not the main-window pixel width |
| Autonomous refresh aliasing | Copies the 'initially there' list before extending (the alias grew the session list each refresh); order-preserving dedupe replaces order-scrambling `list(set())` |
| Evaluation-regions cancel no-op | Backup is a structural copy (drags mutate the dicts in place; live pyqtgraph refs excluded) |
| Settings-tab destruction | `make_tabs_visible` guards on current state — hiding-when-hidden removed the Settings tab (reachable via CropError during session load) |
| TableHandler dead methods | `np.float` (removed in NumPy ≥1.24) → `float`; `QtGui.QTableWidgetItem`/`QTableWidgetSelectionRange` → the correct already-imported QtWidgets names |
| Recon table widths | Copy/paste slip: uses its own `recon_table_columns` |
| Run_*/SummedImg globs | `sorted()` for deterministic picks |

### Deferred with issues (need domain input, not guesses)
- **#181** TOF ROI transpose — display-coupled; needs visual verification on a live GUI before changing what operators see
- **#182** SNAP-vs-VENUS default source-detector distance — the correct VENUS constant is an instrument-team decision

## Test plan

- `pixi run test`: **33 passed**, 151 skipped (8 new H4 classification tests; the #178 contract suite still green)
- pre-commit clean across all ten touched files

Remaining in the packet: PR 5 (CI/tooling — SHA pins, permissions, grype, boa→pixi-build, SPEC 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)