### PR TITLE
fix(ci): use absolute local channel for conda pkg-install (unblocks promotion)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,6 +27,14 @@ jobs:
       - name: build conda package
         run: pixi run -e package build-conda
 
+      # micromamba reads a LOCAL channel only from an absolute path; a bare
+      # "conda.recipe" is resolved as a *remote* channel (404 on anaconda.org).
+      # Stage the built noarch package into a clean absolute channel dir.
+      - name: Stage built package into a local channel
+        run: |
+          mkdir -p /tmp/local-channel/noarch
+          cp conda.recipe/noarch/hyperctui*.tar.bz2 /tmp/local-channel/noarch/
+
       # conda-verify is archived (no modern-Python builds); verification is
       # the org-standard pkg-install (micromamba env from the local channel)
       # + pkg-verify (import check) pair
@@ -35,7 +43,7 @@ jobs:
         uses: neutrons/conda-actions/pkg-install@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
         with:
           package-name: hyperctui
-          local-channel: conda.recipe
+          local-channel: /tmp/local-channel
 
       - name: Verify conda package
         uses: neutrons/conda-actions/pkg-verify@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2


### PR DESCRIPTION
## Problem

The `next → qa` promotion failed `package.yml`'s conda-build job at **Install built conda package**:
```
critical libmamba Multiple errors occurred:
  Transfer finalized, status: 404 [https://conda.anaconda.org/conda.recipe/noarch/repodata.json]
  Subdir conda.recipe/noarch not loaded!
```
`pkg-install` was passed `local-channel: conda.recipe` (a **relative** path); micromamba resolves a bare name as a **remote** channel and 404s, so the just-built package is never found. Latent because `package.yml` only runs on qa/main/tags — never on `next` — so it first surfaced on promotion (PR #184 introduced the pkg-install step).

## Fix

Stage the built noarch package into a clean **absolute** channel dir and point `pkg-install` there (matching the working CGC `package.yaml` pattern):
```yaml
- name: Stage built package into a local channel
  run: |
    mkdir -p /tmp/local-channel/noarch
    cp conda.recipe/noarch/hyperctui*.tar.bz2 /tmp/local-channel/noarch/
- ... pkg-install with local-channel: /tmp/local-channel
```

Needed to complete the (in-progress) next→qa→main promotion + first NeuNorm-2.0-era release.

🤖 Assisted with [Claude Code](https://claude.com/claude-code)