### PR TITLE
fix(ci): fetch tags in package.yml so versioningit versions correctly

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # versioningit needs full history + tags, else it falls back to
+          # default-tag (0.1.0) and the built package is mis-versioned
+          fetch-depth: 0
+          fetch-tags: true
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: pyproject.toml
@@ -74,6 +79,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # versioningit needs full history + tags, else it falls back to
+          # default-tag (0.1.0) and the built package is mis-versioned
+          fetch-depth: 0
+          fetch-tags: true
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: pyproject.toml


### PR DESCRIPTION
## Problem

Second latent `package.yml` bug surfaced by the next→qa→main promotion: even after the local-channel fix (#186), the green qa build packaged **`hyperctui-0.1.0`** — not the real versioningit version (`1.1.0.dev*`). Cause: both `package.yml` checkouts are bare `actions/checkout@v6` (shallow, no tags), so `versioningit` can't `git describe` the release tags and falls back to `default-tag = 0.1.0`. A tagged release would publish a mis-versioned package.

## Fix

Add `fetch-depth: 0` + `fetch-tags: true` to both checkouts (build job + pypi-publish), matching CGC's working `package.yaml`.

## Why latent

`package.yml` only runs on qa/main/tags, never on `next` — so neither this nor #186 was exercised until promotion. Both now fixed; the next qa run should build `1.1.0.dev99` (and a `v1.1.0` tag → `1.1.0`).

🤖 Assisted with [Claude Code](https://claude.com/claude-code)