### PR TITLE
fix(ci): ignore 7 more python 3.12 advisories blocking the Grype gate

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -56,6 +56,30 @@ ignore:
   - vulnerability: CVE-2026-8328
     package:
       name: python
+  # Newer advisories the DB began flagging after 2026-06-11; all fixed only in
+  # 3.13+/prerelease builds, none in the 3.12 line (see FIXED-IN: 3.13.14 /
+  # 3.14.x / 3.15.0bx). The default env is capped at 3.12 by boa/conda-build.
+  - vulnerability: CVE-2026-1502
+    package:
+      name: python
+  - vulnerability: CVE-2026-3298
+    package:
+      name: python
+  - vulnerability: CVE-2026-4786
+    package:
+      name: python
+  - vulnerability: CVE-2026-6019
+    package:
+      name: python
+  - vulnerability: CVE-2026-6100
+    package:
+      name: python
+  - vulnerability: CVE-2026-9669
+    package:
+      name: python
+  - vulnerability: CVE-2026-12003
+    package:
+      name: python
 
   # Qt 5.15 open-source receives no upstream fixes (patches land in Qt 6
   # only), so every qt 5.15.x advisory counts as "fixable" while no fix is


### PR DESCRIPTION
## Why

The **Scan dependencies with Grype** gate (`--fail-on medium --only-fixed`) scans the default env (**python 3.12.13**) and has been failing (e.g. on #193/#194) because the vulnerability DB keeps adding cpython advisories faster than they land in `.grype.yaml`. All 7 below are fixed **only** in 3.13+/prerelease builds — none in the 3.12 line — and the default env is capped at 3.12 by the boa/conda-build constraint, so no installable fix exists here. This matches the file's existing accepted-risk rationale.

| CVE | Severity | Fixed in (per grype) |
|---|---|---|
| CVE-2026-6100 | High | 3.13.14 / 3.14.5rc1 / 3.15.0b1 |
| CVE-2026-3298 | High | 3.13.14 / 3.14.5rc1 / 3.15.0b1 |
| CVE-2026-9669 | High | 3.13.14 / 3.14.6 / 3.15.0b3 |
| CVE-2026-4786 | High | 3.13.14 / 3.14.5rc1 / 3.15.0b1 |
| CVE-2026-1502 | Medium | 3.13.14 / 3.14.5rc1 / 3.15.0b1 |
| CVE-2026-6019 | Medium | 3.13.14 / 3.14.5rc1 / 3.15.0b1 |
| CVE-2026-12003 | Medium | 3.15.0b3 |

## Verification (local)

Scanned this repo's default env with grype 0.115.0 + this config:
```
grype --fail-on medium --only-fixed dir:.pixi/envs/default
→ No vulnerabilities found
```

## Note — this is a treadmill

7 new CVEs accrued in ~3 weeks. The per-CVE list will keep needing top-ups on every DB update. If the maintainers prefer, a single version-scoped ignore (`package: {name: python, version: 3.12.13}`) would cover all current+future 3.12.13 CVEs and auto-expire when python is bumped — happy to switch to that instead. Kept per-CVE here to match the existing convention.

Assisted-With: Claude Opus 4.8 (1M context)