### PR TITLE
ci: SHA-pin all actions/* (supply-chain hardening)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # versioningit needs full history + tags, else it falls back to
           # default-tag (0.1.0) and the built package is mis-versioned
@@ -78,7 +78,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # versioningit needs full history + tags, else it falls back to
           # default-tag (0.1.0) and the built package is mis-versioned

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -25,7 +25,7 @@ jobs:
         # env was previously held at Python 3.11 by the packaging stack
         environment: [py312, py313, py314]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: pyproject.toml
@@ -48,7 +48,7 @@ jobs:
     name: wheel packages required data files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       security-events: write # required for upload-sarif
       actions: read # upload-sarif on private repos
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           manifest-path: pyproject.toml

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -13,7 +13,7 @@ jobs:
   pixi-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:


### PR DESCRIPTION
Pin every GitHub-published `actions/*` (and `github/codeql-action/*`) reference to a full commit SHA with a `# vX.Y.Z` comment, matching the org convention and the already-SHA-pinned third-party actions. **Same versions currently in use — pure format change, no behavior change.** Dependabot maintains SHA pins + comments going forward.

Assisted-With: Claude Opus 4.8 (1M context)